### PR TITLE
Add /generate6 endpoint for IPv6 allocations

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -4,7 +4,7 @@ addEventListener('fetch', event => {
 
 class ClientError extends Error {}
 
-const { routes_from_rir_stats } = wasm_bindgen;
+const { routes_from_rir_stats, routes_from_rir_stats6 } = wasm_bindgen;
 
 /**
  * Fetch and log a request
@@ -19,6 +19,9 @@ async function handleRequest(request) {
       break;
     case '/generate':
       return await handleGenerate(request);
+      break;
+    case '/generate6':
+      return await handleGenerate6(request);
       break;
     default:
       return new Response(`Resource Not Found at Endpoint ${url.pathname}`, { status: 404 });
@@ -49,6 +52,10 @@ async function handleGenerate(request) {
       return new Response(`Server Error: ${e}`, { status: 500 });
     }
   }
+}
+
+async function handleGenerate6(request) {
+    return new Response(routes_from_rir_stats6("foo", "bar"), { contentType: "text/plain" });
 }
 
 async function fetch_rir_stats(registry) {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -18,17 +18,17 @@ async function handleRequest(request) {
       return Response.redirect("https://github.com/Gowee/chnroutes-cfworker#api", 302);
       break;
     case '/generate':
-      return await handleGenerate(request);
+      return await handleGenerate(request, false);
       break;
     case '/generate6':
-      return await handleGenerate6(request);
+      return await handleGenerate6(request, true);
       break;
     default:
       return new Response(`Resource Not Found at Endpoint ${url.pathname}`, { status: 404 });
   }
 }
 
-async function handleGenerate(request) {
+async function handleGenerate(request, ipv6) {
   try {
     const params = (new URL(request.url)).searchParams;
     const countries = (params.get("countries") || "!").toUpperCase();
@@ -41,7 +41,8 @@ async function handleGenerate(request) {
       const data = await fetch_rir_stats(registry);
       rir_stats.push(data);
     }
-    return new Response(routes_from_rir_stats(rir_stats.join("\n"), countries), { contentType: "text/plain" });
+    const fn = ipv6 ? routes_from_rir_stats6 : routes_from_rir_stats;
+    return new Response(fn(rir_stats.join("\n"), countries), { contentType: "text/plain" });
     //return new Response("Boom");
   }
   catch (e) {
@@ -52,10 +53,6 @@ async function handleGenerate(request) {
       return new Response(`Server Error: ${e}`, { status: 500 });
     }
   }
-}
-
-async function handleGenerate6(request) {
-    return new Response(routes_from_rir_stats6("foo", "bar"), { contentType: "text/plain" });
 }
 
 async function fetch_rir_stats(registry) {


### PR DESCRIPTION
This PR adds a `/generate6` endpoint for IPv6 address allocations, with the same arguments and requirements as `/generate`. IPv6 is implemented as a separate endpoint because this allows a more flexible and convenient usage (e.g. when used in `ipset` which distinguish `inet6` from `inet`).

However due to Rust's type system not strong enough (such as  https://github.com/rust-lang/rust/issues/20041), this also resulted in code duplication which diverge  both in type (`Ipv4Addr` vs `Ipv6Addr`, `u32` vs `u128`) and semantic (`value` means count in v4, where it also means prefix length in v6). To address this code duplication a reconsideration over http endpoints is needed.